### PR TITLE
Fix ports for SSR in documentation

### DIFF
--- a/samples/react-typescript/README.md
+++ b/samples/react-typescript/README.md
@@ -49,8 +49,8 @@ And now get wild using the following most important commands:
 | `npm run start:disconnected` | http://localhost:3000 | Client side only development, disconnected from sitecore |
 | `npm run start:connected` | http://localhost:3000 | Client side only development, connected to sitecore |
 | `npm run start:storybook` | http://localhost:9001 | Use storybook for out-of-context component development |
-| `npm run serve:disconnected ` | http://localhost:3000 (client-side rendering) and http://localhost:3000 (server-side rendering) | Both client side and server side rendering, disconnected from sitecore |
-| `npm run serve:connected ` | http://localhost:3000 (client-side rendering) and http://localhost:3000 (server-side rendering) | Both client side and server side rendering, connected to sitecore |
+| `npm run serve:disconnected ` | http://localhost:3000 (client-side rendering) and http://localhost:3001 (server-side rendering) | Both client side and server side rendering, disconnected from sitecore |
+| `npm run serve:connected ` | http://localhost:3000 (client-side rendering) and http://localhost:3001 (server-side rendering) | Both client side and server side rendering, connected to sitecore |
 | `npm run docker:build` | N.A. | Build a local Docker image |
 | `npm run docker:run:disconnected` | http://localhost:8888 | run the local Docker image disconnected from Sitecore |
 | `npm run docker:run:connected` | http://localhost:8888 | run the local Docker image connected to Sitecore |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changed port 3000 to 3001 in the documentation

## Motivation
The documentation was indicating the same port for both the client side rendering and the server-side rendering.

## How Has This Been Tested?
No tests needed: this is a fix for the documentation.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] I have read the Contributing guide. => There is none, right?
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation. => it is a change to the documentation
